### PR TITLE
Display diff output for pipeline logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-if [[ -n "$(terraform fmt -check -recursive)" ]]; then
+if [[ -n "$(terraform fmt -check -recursive -diff)" ]]; then
   echo "Some terraform files need be formatted, run 'terraform fmt' to fix";
   exit 1;
 fi


### PR DESCRIPTION
# Description

Thanks for developing this GH action.

It would be good to see the diff output in the pipeline logs when an error is found.

This will display something like:
```
--- old/cdn.tf
+++ new/cdn.tf
@@ -50,7 +50,7 @@
   comment         = "CDN"
   is_ipv6_enabled = true
   default_cache_behavior {
-    allowed_methods      = ["GET", "HEAD"]
+    allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
     compress               = true
     target_origin_id       = "origin"
```