### PR TITLE
fix: Added -recursive option to command hint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 if [[ -n "$(terraform fmt -check -recursive -diff)" ]]; then
-  echo "Some terraform files need be formatted, run 'terraform fmt' to fix";
+  echo "Some terraform files need to be formatted. Run 'terraform fmt -recursive' to fix them.";
   exit 1;
 fi


### PR DESCRIPTION
# Description

This PR will adjust the hint, that shows up when files are not formatted correctly.
I added the `-recursive` option so the hint is more precise.

## Rationale

For me, who never used the subcommand `fmt` before, it was confusing why this command does nothing to my code. I had to investigate this a few minutes to realize that I need the `-recursive` option, because the wrong formatted code was not in the root of my project.
I want that others have a more precise solution to wrong formatted code.

## Issues Resolved

No related issue.

## Check List

- [x] ~New functionality includes testing~.
- [x] New functionality has been documented in the README if applicable.
